### PR TITLE
Minor update to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 **This is an archive of ngn/apl**
 
 **Its author thinks it has served its purpose and has become a distraction.
-Most of his free time now is devoted to creating a free [implementation](https://git.sr.ht/~ngn/k) of [K6](https://en.wikipedia.org/wiki/K_(programming_language)) and he encourages people to use that instead.**
+Most of his free time now is devoted to creating a free [implementation](https://codeberg.org/ngn/k) of [K6](https://en.wikipedia.org/wiki/K_(programming_language)) and he encourages people to use that instead.**
 
 ----
 


### PR DESCRIPTION
A minor update to the README. 

Current version of the README's implementation link for ngn's k9 points to a deleted page on git.sr.ht. I've updated this link to point to what I believe is the currently active repository for that project on codeberg. 